### PR TITLE
fix incorrect discord help channel link on template

### DIFF
--- a/categories/blog-posts.md
+++ b/categories/blog-posts.md
@@ -53,7 +53,7 @@ Your contribution cannot be accepted.
 
 "Blog posts" category is directly related to open-source -just like every category at Utopian-. Please, post your normal blogging content on Steemit.
 
-You can contact us on [Discord](https://discord.gg/UCvqCsx).
+You can contact us on [Discord](https://discord.gg/uTyJkNm).
 **[[utopian-moderator]](https://utopian.io/moderators)**
 ```
 2. Wrong category
@@ -67,7 +67,7 @@ on the correct category.
 
 The correct category you should re-post is **translations**.
 
-You can contact us on [Discord](https://discord.gg/UCvqCsx).
+You can contact us on [Discord](https://discord.gg/uTyJkNm).
 **[[utopian-moderator]](https://utopian.io/moderators)**
 ```
 

--- a/categories/development.md
+++ b/categories/development.md
@@ -65,7 +65,7 @@ If possible, it shouldn't be directly included in the project. ...
 
 Your contribution cannot be approved. We cannot evaluate a development contribution, if there's no public history, such as that on GitHub, for open source projects, that were meant to be open source right from the beginning. Many users simply upload their old projects to GitHub, just to have the "Open Source" label, to get a reward. On Utopian we want actively maintained and promising Open Source projects and no outdated private projects. Simply uploading files to GitHub is not the way to go. You need to carefully prepare your project and provide information for others, both users and developers, to participate. The project should be up-to-date and documented and the development should happen in an organized and transparent manner, using Git/GitHub, to qualify as an open source project on Utopian.
 
-For questions and feedback you can contact us on \[Discord](https://discord.gg/UCvqCsx).
+For questions and feedback you can contact us on \[Discord](https://discord.gg/uTyJkNm).
 
 \**\[[utopian-moderator]](https://utopian.io/moderators)**
 
@@ -85,7 +85,7 @@ Your project is too simple and has more the character of a textbook example. Thi
  
 Please only submit projects of decent quality, that you want to actively maintain and develop. Instead you can also try to contribute to other, more established projects.
  
-For questions and feedback you can contact us on \[Discord](https://discord.gg/UCvqCsx).
+For questions and feedback you can contact us on \[Discord](https://discord.gg/uTyJkNm).
  
 \**\[[utopian-moderator]](https://utopian.io/moderators)**
 


### PR DESCRIPTION
Current template link bring us to collaborators channel. So it need to fix to the help channel.