### PR TITLE
fix help channel link and some typo error on translation.md

### DIFF
--- a/categories/translation.md
+++ b/categories/translation.md
@@ -2,7 +2,7 @@
 
 **Reminder:** Please read the current [Utopian Rules](https://utopian.io/rules) first, to bring yourself up to date. This file might not be up to date. It was last updated on *06 Jan 2018*.
 
-The [Translation](https://utopian.io/translation/review) category has historically been the most popular category on utopian-io. Because of that, the quality of the translation is the leading factor in the evaluation of contributions. The contributions must be submitted on [crowdin.com](https://crowdin.com) or [github.com](https://github.com), and in case of github, must be submitted as a pull request and merged into the repository before they can be accepted. As a moderator of this category, you'll need to be fluent in English and flawless in your mother tongue. Any translations that aren't close to perfection aren't welcome on utopian.
+The [Translation](https://utopian.io/translation/review) category has historically been the most popular category on utopian-io. Because of that, the quality of the translation is the leading factor in the evaluation of contributions. The contributions must be submitted on [crowdin.com](https://crowdin.com) or [github.com](https://github.com), and in case of GitHub, must be submitted as a pull request and merged into the repository before they can be accepted. As a moderator of this category, you'll need to be fluent in English and flawless in your mother tongue. Any translations that aren't close to perfection aren't welcome on utopian.
 
 Ideally, a translation contribution should always be reviewed by a moderator that can understand the submitted language and find mistakes in the translation. If that's not possible, posts are to be reviewed by using various translators and by comparing the contribution to results of machine translation. If the results match, the post shall be rejected.
 
@@ -12,9 +12,9 @@ Ideally, a translation contribution should always be reviewed by a moderator tha
 >This rule is to be enforced without any exception. The moderators are expected to check how much of the translation is real text, compared to code and repeated strings. Anything that isn't real text shall not be counted towards this minimum word count.
 
 * You could translate less than 500 words if the project itself has less than 500 words to be translated in total.
->This only applies to projects which have less than 500 words total. If a single file of the project has less than 500 words, the contributor is expected to start working on an another file. If the project was almost fully translated and there's less then 500 words left, but the project has more than 500 words total, the contribution shall not be accepted, except in edge cases that should be discussed with your supervisor.
+>This only applies to projects which have less than 500 words total. If a single file of the project has less than 500 words, the contributor is expected to start working on an another file. If the project was almost fully translated and there's less than 500 words left, but the project has more than 500 words total, the contribution shall not be accepted, except in edge cases that should be discussed with your supervisor.
 
-* Only translations on CrowdIn or Github are accepted. You should not translate the words and provide them in your Utopian post directly.
+* Only translations on Crowdin or GitHub are accepted. You should not translate the words and provide them in your Utopian post directly.
 >Any translation submited to an another website should be permamently hidden on sight, while informing the contributor about this rule and allowing him to contribute again with this rule in mind.
 
 * This category is meant only for translations you have updated or created for an Open Source project.
@@ -23,14 +23,14 @@ Ideally, a translation contribution should always be reviewed by a moderator tha
 * You must be the author of the translation and provide a way to verify your work.
 >Any attempt at plagiarism should be immediatelly reported to your supervisor, and the post should be permamently hidden on sight. Plagiarism is not welcome on utopian and there will be harsh actions taken against any plagiarist.
 
-* If your username on CrowdIn or similar translation platforms does not correspond to the Utopian username you must provide proof you are the owner by providing a screenshot of the logged in session in the translation platform.
+* If your username on Crowdin or similar translation platforms does not correspond to the Utopian username you must provide proof you are the owner by providing a screenshot of the logged in session in the translation platform.
 >Just as with GitHub in the [Development](https://utopian.io/development/review) or [Documentation](https://utopian.io/documentation/review) categories, proof of identity is required before the post can be accepted. If there's any suspicion of plagiarism, report the post to your supervisor immediately.
 
 * Same translations from different authors will be accepted if the moderator can recognise the newest translation has better quality.
 >The quality of new translations has to be significantly better for this rule to be enforced. 
 
 * If the provided translation is obviously machine-translated, the contribution will be rejected.
->Such user should be reported to your supervisor immediately. If the post is machine-translated using crowdin's build in translation tools, it may be accepted as long as the translations are 100% correct and are not a majority of all translations made.
+>Such user should be reported to your supervisor immediately. If the post is machine-translated using Crowdin's build in translation tools, it may be accepted as long as the translations are 100% correct and are not a majority of all translations made.
 
 ### Post Formatting
 
@@ -41,7 +41,7 @@ All contributions submitted to Utopian, including translations, **must be formal
 * An information on how much progress was achieved by the contribution (at least the ammount of words).
 * Screeshots with proof of work and identity.
 * A short description of the translation process.
-* The link to the Github repository.
+* The link to the GitHub repository.
 * The link to contributor's Crowdin profile or his activity.
 * The link to project's Crowdin page.
 
@@ -65,10 +65,10 @@ This is extremely important, as Utopian can't gain the trust of project owners a
 - [ ] Are there no obvious mistakes in the translations? This includes machine-translations.
 - [ ] Is the translation submitted to Crowdin?
   - [ ] Is the repository correct?
-  - [ ] Was there any activity withing the past year?
-- [ ] Is the translation submitted to Github?
+  - [ ] Was there any activity within the past year?
+- [ ] Is the translation submitted to GitHub?
   - [ ] Is the repository correct?
-  - [ ] Was there any activity withing the past year?
+  - [ ] Was there any activity within the past year?
   - [ ] Is the Pull Request already merged?
   - [ ] Was it merged within the past 30 days?
 
@@ -81,7 +81,7 @@ Your contribution cannot be approved yet. See the [Utopian Rules](https://utopia
 
 We've found definitive proof that you've used Machine-Translations in this contribution. This contribution will not be accepted, and the decision is absolute. Your account has been suspended until you contact a moderator to resolve this issue.
 
-You can contact us on [Discord](https://discord.gg/UCvqCsx).
+You can contact us on [Discord](https://discord.gg/uTyJkNm).
 **[[utopian-moderator]](https://utopian.io/moderators)** 
 ```
 
@@ -92,7 +92,7 @@ Your contribution cannot be approved yet. See the [Utopian Rules](https://utopia
 
 Your contribution has to be formal and only include information about the project or the translation process. Any other information is unnecessary, and thus not acceptable.
 
-You can contact us on [Discord](https://discord.gg/UCvqCsx).
+You can contact us on [Discord](https://discord.gg/uTyJkNm).
 **[[utopian-moderator]](https://utopian.io/moderators)** 
 ```
 
@@ -103,7 +103,7 @@ Your contribution cannot be approved yet. See the [Utopian Rules](https://utopia
 
 Your contribution contains too much code and/or too many repeated strings. Remember, that these don't count towards the minimum word count required in this category.
 
-You can contact us on [Discord](https://discord.gg/UCvqCsx).
+You can contact us on [Discord](https://discord.gg/uTyJkNm).
 **[[utopian-moderator]](https://utopian.io/moderators)** 
 ```
 


### PR DESCRIPTION
Fix channel link (refer to #11 ) and some typo errors

Github -> GitHub, CrowdIn -> Crowdin would be correct
